### PR TITLE
Change xrpcharts.ripple.com to livenet.xrpl.org

### DIFF
--- a/src/components/HelloWorld.vue
+++ b/src/components/HelloWorld.vue
@@ -648,7 +648,7 @@
                                 >
                                   <td class="Tab4">
                                     <a
-                                      v-bind:href="'https://xrpcharts.ripple.com/#/validators/' + q.validation_public_key"
+                                      v-bind:href="'https://livenet.xrpl.org/validators/' + q.validation_public_key"
                                       target="_blank"
                                       style="text-decoration:none;"
                                     >{{ q.validation_public_key }}</a>

--- a/src/components/HelloWorld.vue
+++ b/src/components/HelloWorld.vue
@@ -764,7 +764,7 @@
                                 >
                                   <td class="Tab4">
                                     <a
-                                      v-bind:href="'https://xrpcharts.ripple.com/#/validators/' + q.validation_public_key"
+                                      v-bind:href="'https://livenet.xrpl.org/validators/' + q.validation_public_key"
                                       target="_blank"
                                       style="text-decoration:none;"
                                     >{{ q.validation_public_key }}</a>

--- a/src/components/RipTabTwo.vue
+++ b/src/components/RipTabTwo.vue
@@ -293,7 +293,7 @@
                       <tr scope="row" v-for="q in validatorsData.validators" :key="`ijk-${q.validation_public_key}`">
                         <td class="Tab4">
                           <a
-                            :href="'https://xrpcharts.ripple.com/#/validators/' + q.validation_public_key"
+                            :href="'https://livenet.xrpl.org/validators/' + q.validation_public_key"
                             target="_blank"
                             class="pubkeyval"
                           >&nbsp;&nbsp;{{ q.validation_public_key }}</a>

--- a/src/components/alldata.vue
+++ b/src/components/alldata.vue
@@ -568,7 +568,7 @@
                                 >
                                   <td class="Tab4">
                                     <a
-                                      v-bind:href="'https://xrpcharts.ripple.com/#/validators/' + q.validation_public_key"
+                                      v-bind:href="'https://livenet.xrpl.org/validators/' + q.validation_public_key"
                                       target="_blank"
                                       style="text-decoration:none;"
                                     >{{ q.validation_public_key }}</a>


### PR DESCRIPTION
Due to deprecated xrpcharts.ripple.com 